### PR TITLE
 Add: GRIB support

### DIFF
--- a/cdo.spec
+++ b/cdo.spec
@@ -1,6 +1,6 @@
 Name:           cdo
 Version:        2.2.0
-Release:        3
+Release:        4
 Summary:        Climate Data Operators
 License:        GPLv2
 URL:            https://code.zmaw.de/projects/cdo
@@ -11,6 +11,7 @@ BuildRequires:  gcc-c++
 BuildRequires:  gcc-gfortran
 BuildRequires:  netcdf-cxx-devel
 BuildRequires:  hdf5-devel
+BuildRequires:  eccodes-devel
 
 %description
 CDO is a collection of command line Operators to manipulate and analyse Climate model Data.
@@ -34,7 +35,7 @@ Authors:
 
 
 %build
-%configure --prefix=%{_prefix} --with-netcdf --with-hdf5
+%configure --prefix=%{_prefix} --with-netcdf --with-hdf5 --with-eccodes
 make 
 
 %install
@@ -50,6 +51,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_prefix}/bin/cdo
 
 %changelog
+* Wed Jun 28 2023 - Götz Grimmer <goetz-dev@web.de> - 2.2.0-4
+- Add GRIB support
+
 * Fri May 19 2023 - Emanuele Di Giacomo <edigiacomo@arpae.it> - 2.2.0-3
 - Add python3 in BuildRequires
 


### PR DESCRIPTION
  
Add GRIB and GRIB2 support for cdo. Tested on Fedora 38

Tested on my local machine